### PR TITLE
build.gradle changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ version = "1.0.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
+    jcenter()
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,9 @@ plugins {
     kotlin("jvm") version "1.3.71"
 }
 
+// Must always be updated along with plugins block
+val kotlinVersion = "1.3.71"
+
 group = "io.github.random-internet-cat"
 version = "1.0.0-SNAPSHOT"
 
@@ -10,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("stdlib-jdk8", kotlinVersion))
 }
 
 tasks {


### PR DESCRIPTION
* Adds kotlinVersion variable in order to ensure that a consistent version of kotlin packages is always used
* Adds jcenter as a repository because a bunch of things need it
